### PR TITLE
Add spec for when user has other applications

### DIFF
--- a/spec/features/regional_admin/viewing_friends_with_active_applications_spec.rb
+++ b/spec/features/regional_admin/viewing_friends_with_active_applications_spec.rb
@@ -23,24 +23,46 @@ RSpec.describe 'Regional Admin views friends with active applications', type: :f
       end
     end
 
-    it 'closes an application and destroys the remote user_friend_associations' do
-      visit regional_admin_region_friend_path(region, friend)
+    describe "without other applications" do
+      it 'closes an application and destroys the remote user_friend_associations' do
+        visit regional_admin_region_friend_path(region, friend)
 
-      category = application.category.titlecase
-      click_on("Close #{category} Application")
+        category = application.category.titlecase
+        click_on("Close #{category} Application")
 
-      within '#friends-with-active-applications' do
-        expect(page).to_not have_link(friend.name)
+        within '#friends-with-active-applications' do
+          expect(page).to_not have_link(friend.name)
+        end
+
+        expect(page).to have_content('Friends with Active Applications')
+
+        success_text = 'Application closed and assigned remote clinic lawyers removed. Friend has been removed from Active Applications dashboard.'
+        expect(page).to have_content(success_text)
+
+        expect(friend.reload.users).to be_empty
+
+        expect(application.reload.status).to eq('closed')
       end
+    end
 
-      expect(page).to have_content('Friends with Active Applications')
+    describe "with other applications" do
+      let!(:other_application) { create :application, friend: friend, status: 'in_review', category: "sijs" }
 
-      success_text = 'Application closed and assigned remote clinic lawyers removed. Friend has been removed from Active Applications dashboard.'
-      expect(page).to have_content(success_text)
+      it 'closes an application and does not destroy the remote user_friend_associations' do
+        visit regional_admin_region_friend_path(region, friend)
 
-      expect(friend.reload.users).to be_empty
+        category = application.category.titlecase
+        click_on("Close #{category} Application")
 
-      expect(application.reload.status).to eq('closed')
+        expect(page).to have_link(friend.name)
+
+        success_text = 'Application closed.'
+        expect(page).to have_content(success_text)
+
+        expect(friend.reload.users).to match_array([remote_clinic_lawyer])
+
+        expect(application.reload.status).to eq('closed')
+      end
     end
   end
 


### PR DESCRIPTION
This adds the second spec from this issue: https://github.com/CZagrobelny/new_sanctuary_asylum/issues/90

```

    When the friend has at least one OTHER application with a 'status' in the following: :in_review, :changes_requested, :approved

    the application status is 'closed'
    the friend's user_friend_associations where remote=true are NOT destroyed
    the following success message is displayed: 'Application closed.'
    the regional admin is redirected to the appropriate path

```